### PR TITLE
fix: POPタイムラインのレポートを全文表示に変更

### DIFF
--- a/frontend/src/components/pop/TimelineReportCard.tsx
+++ b/frontend/src/components/pop/TimelineReportCard.tsx
@@ -70,7 +70,7 @@ export default function TimelineReportCard({
         {/* 要約 */}
         <div className="bg-gradient-to-r from-blue-50 to-indigo-50 p-3 rounded-lg">
           <h4 className="text-xs font-semibold text-blue-800 mb-1">要約</h4>
-          <p className="text-xs text-gray-700 line-clamp-3">{report.summary}</p>
+          <p className="text-xs text-gray-700 whitespace-pre-wrap">{report.summary}</p>
         </div>
 
         {/* 得られた洞察 */}
@@ -78,7 +78,7 @@ export default function TimelineReportCard({
           <h4 className="text-xs font-semibold text-gray-700 mb-1">
             得られた洞察
           </h4>
-          <p className="text-xs text-gray-600 line-clamp-3">
+          <p className="text-xs text-gray-600 whitespace-pre-wrap">
             {report.insights_summary}
           </p>
         </div>
@@ -92,7 +92,7 @@ export default function TimelineReportCard({
                 : `${report.display_name}さん`}
               への関連付け
             </h4>
-            <p className="text-xs text-gray-700 line-clamp-3">
+            <p className="text-xs text-gray-700 whitespace-pre-wrap">
               {report.context_analysis}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- POPタイムラインのレポートカードで `line-clamp-3` による3行制限を削除
- `whitespace-pre-wrap` に変更し、要約・得られた洞察・関連付けを全文表示

## Test plan
- [x] POPタイムラインでレポートカードのテキストが全文表示されることを確認
- [x] CIのビルド・lintが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)